### PR TITLE
Fix dark theme resource definition

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,16 +1,12 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
-    <style name="Theme.Maxscraper" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_200</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/black</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_200</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Night variant for the app theme -->
+    <style name="Theme.MaxScraper" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/ms_primary</item>
+        <item name="colorPrimaryVariant">@color/ms_primaryVariant</item>
+        <item name="colorSecondary">@color/ms_secondary</item>
+        <item name="android:colorBackground">@android:color/background_dark</item>
+        <item name="colorSurface">@android:color/background_dark</item>
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="Theme.Maxscraper" parent="Theme.Material3.DayNight.NoActionBar"/>
-</resources>


### PR DESCRIPTION
## Summary
- replace the night theme resource with one that matches the `Theme.MaxScraper` style used by the app
- remove the unused Material3 stub theme file so only the real theme is packaged

## Testing
- not run (Android SDK is not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68def58acac8832a9d4915b37af5a44f