### PR TITLE
Improve media detection for browser scraping

### DIFF
--- a/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
+++ b/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
@@ -13,7 +13,6 @@ import android.webkit.WebChromeClient
 import android.webkit.WebChromeClient.CustomViewCallback
 import android.webkit.WebSettings
 import android.webkit.WebView
-import android.webkit.WebViewClient
 import android.widget.Button
 import android.widget.EditText
 import android.widget.FrameLayout
@@ -115,10 +114,10 @@ class BrowserActivity : AppCompatActivity() {
             }
         }
 
-        webView.webViewClient = object : WebViewClient() {
-            override fun onPageFinished(view: WebView?, url: String?) {
+        webView.webViewClient = object : NetSnifferWebViewClient(this, webView) {
+            override fun onPageFinished(view: WebView, url: String) {
                 super.onPageFinished(view, url)
-                if (!url.isNullOrBlank() && (url.startsWith("http://") || url.startsWith("https://"))) {
+                if (url.startsWith("http://") || url.startsWith("https://")) {
                     lastGoodUrl = url
                 }
                 // Capture og:image for thumbnails

--- a/app/src/main/java/com/example/maxscraper/MediaDetector.kt
+++ b/app/src/main/java/com/example/maxscraper/MediaDetector.kt
@@ -23,7 +23,9 @@ object MediaDetector {
     fun report(url: String) {
         val L = url.lowercase()
         if (L.endsWith(".ts")) return
-        if (!(L.contains(".m3u8") || L.endsWith(".mp4"))) return
+        val isHls = MediaFilter.isProbableHls(url)
+        val isMp4 = MediaFilter.isProbableMp4(url)
+        if (!isHls && !isMp4) return
         try {
             val host = URI(url).host?.lowercase()
             if (isIgnoredHost(host)) return

--- a/app/src/main/java/com/example/maxscraper/NetSnifferWebViewClient.kt
+++ b/app/src/main/java/com/example/maxscraper/NetSnifferWebViewClient.kt
@@ -36,7 +36,7 @@ class NetSnifferWebViewClient(
     private fun looksLikeMedia(u: String): Boolean {
         val L = u.lowercase()
         if (L.endsWith(".ts")) return false
-        if (!(L.endsWith(".mp4") || L.contains(".m3u8"))) return false
+        if (!(MediaFilter.isProbableMp4(u) || MediaFilter.isProbableHls(u))) return false
         val host = runCatching { Uri.parse(u).host?.lowercase() ?: "" }.getOrElse { "" }
         if (MediaDetector.isIgnoredHost(host)) return false
         return true
@@ -49,7 +49,8 @@ class NetSnifferWebViewClient(
               function post(u, playing){
                 try {
                   if (!u) return;
-                  if (u.indexOf('.m3u8')<0 && !u.toLowerCase().endsWith('.mp4')) return;
+                  var low = u ? u.toLowerCase() : '';
+                  if (low.indexOf('.m3u8')<0 && low.indexOf('.mp4')<0) return;
                   if (playing) window.DetectorBridge.playing(u); else window.DetectorBridge.hit(u);
                 } catch(e){}
               }


### PR DESCRIPTION
## Summary
- integrate the net sniffer web view client into the browser so network traffic is reported to the detector
- reuse the shared media filter heuristics so mp4 URLs with query parameters are detected
- relax the injected detector JS filter to forward hls/mp4 candidates reliably

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df0fe54fb0832a96a646fffcc7f5cf