### PR TITLE
Fix WebViewClient context reference

### DIFF
--- a/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
+++ b/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
@@ -130,7 +130,7 @@ class BrowserActivity : AppCompatActivity() {
             }
         }
 
-        webView.webViewClient = object : NetSnifferWebViewClient(this, webView) {
+        webView.webViewClient = object : NetSnifferWebViewClient(this@BrowserActivity, webView) {
             override fun onPageFinished(view: WebView, url: String) {
                 super.onPageFinished(view, url)
                 if (url.startsWith("http://") || url.startsWith("https://")) {


### PR DESCRIPTION
## Summary
- ensure BrowserActivity passes the activity context to NetSnifferWebViewClient when creating the WebViewClient

## Testing
- ./gradlew assembleDebug *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08c140df4832a9fe62d746661ed36