### PR TITLE
Handle Instagram CDN cookies when downloading

### DIFF
--- a/app/src/main/java/com/example/maxscraper/CookieHelpers.kt
+++ b/app/src/main/java/com/example/maxscraper/CookieHelpers.kt
@@ -1,0 +1,28 @@
+package com.example.maxscraper
+
+import android.webkit.CookieManager
+
+/**
+ * Collect cookies for the target [url] and (if necessary) fall back to cookies from [referer].
+ * Some CDNs (e.g. Instagram's) require first-party cookies from the page host in order to
+ * authorise the media request even though the media itself is served from a different domain.
+ */
+fun gatherCookies(url: String?, referer: String?): String? {
+    val mgr = CookieManager.getInstance()
+    val collected = linkedSetOf<String>()
+
+    fun addFrom(target: String?) {
+        if (target.isNullOrBlank()) return
+        val raw = runCatching { mgr.getCookie(target) }.getOrNull().orEmpty()
+        if (raw.isBlank()) return
+        raw.split(';')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .forEach { collected += it }
+    }
+
+    addFrom(url)
+    addFrom(referer)
+
+    return if (collected.isEmpty()) null else collected.joinToString(separator = "; ")
+}

--- a/app/src/main/java/com/example/maxscraper/DownloadRepository.kt
+++ b/app/src/main/java/com/example/maxscraper/DownloadRepository.kt
@@ -9,7 +9,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
-import android.webkit.CookieManager
+import com.example.maxscraper.gatherCookies
 import com.example.maxscraper.net.ParallelDownloader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -195,6 +195,7 @@ object DownloadRepository {
                 req.addRequestHeader("Origin", "${u.scheme}://${u.host}")
             }
         }
+        gatherCookies(resolved, referer)?.let { req.addRequestHeader("Cookie", it) }
 
         val id = try {
             dm.enqueue(req)
@@ -248,7 +249,6 @@ object DownloadRepository {
         val ua = UserAgent.defaultForWeb(ctx)
         var url = startUrl
         var hops = 0
-        val cookieMgr = CookieManager.getInstance()
         val seen = HashSet<String>()
 
         while (hops < 5) {
@@ -262,7 +262,7 @@ object DownloadRepository {
                 setRequestProperty("Accept-Language", "en-US,en;q=0.9")
                 setRequestProperty("Accept-Encoding", "identity")
                 setRequestProperty("Range", "bytes=0-0")
-                cookieMgr.getCookie(url)?.let { setRequestProperty("Cookie", it) }
+                gatherCookies(url, referer)?.let { setRequestProperty("Cookie", it) }
                 referer?.let {
                     setRequestProperty("Referer", it)
                     val ru = Uri.parse(it)

--- a/app/src/main/java/com/example/maxscraper/ParallelDownloader.kt
+++ b/app/src/main/java/com/example/maxscraper/ParallelDownloader.kt
@@ -2,7 +2,6 @@ package com.example.maxscraper.net
 
 import android.content.Context
 import android.net.Uri
-import android.webkit.CookieManager
 import android.webkit.WebSettings
 import kotlinx.coroutines.*
 import okhttp3.Request
@@ -10,12 +9,13 @@ import okio.buffer
 import okio.sink
 import java.io.File
 import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
 import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.max
 import com.example.maxscraper.Http
-import java.nio.channels.FileChannel
+import com.example.maxscraper.gatherCookies
 
 object ParallelDownloader {
 
@@ -154,7 +154,6 @@ object ParallelDownloader {
 
     private fun defaultHeaders(ctx: Context, url: String, referer: String?): Map<String, String> {
         val ua = WebSettings.getDefaultUserAgent(ctx)
-        val cookie = CookieManager.getInstance().getCookie(url)
         val h = mutableMapOf(
             "User-Agent" to ua,
             "Accept" to "*/*",
@@ -169,7 +168,7 @@ object ParallelDownloader {
                 h["Origin"] = origin
             } catch (_: Throwable) {}
         }
-        if (!cookie.isNullOrBlank()) h["Cookie"] = cookie
+        gatherCookies(url, referer)?.let { h["Cookie"] = it }
         return h
     }
 


### PR DESCRIPTION
## Summary
- add a helper to combine cookies from the media URL and referring page
- attach the merged cookies to DownloadManager and direct download requests so Instagram CDN URLs retain authentication

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c047b548832a9a97439b1d67eed8