### PR TITLE
Restore media filtering for non-Instagram sites

### DIFF
--- a/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
+++ b/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
@@ -302,10 +302,12 @@ class BrowserActivity : AppCompatActivity() {
     }
 
     private fun filterPlayableMedia(foundUrls: List<String>): List<String> {
-        val normalized = foundUrls.mapNotNull { normaliseMediaUrl(it) }
-        val mp4s = normalized.filter { it.contains(".mp4", true) }
-        val hls = normalized.filter { it.contains(".m3u8", true) }
-        return (if (mp4s.isNotEmpty()) mp4s else hls)
+        val trimmed = foundUrls.map { it.trim() }
+        val mp4s = trimmed.filter { it.contains(".mp4", true) }
+        val hls = trimmed.filter { it.contains(".m3u8", true) }
+        val prioritized = if (mp4s.isNotEmpty()) mp4s else hls
+        return prioritized
+            .mapNotNull { normaliseMediaUrl(it) }
             .distinctBy { runCatching { Uri.parse(it).path ?: it }.getOrElse { it } }
     }
 
@@ -458,7 +460,9 @@ class BrowserActivity : AppCompatActivity() {
     private fun normaliseMediaUrl(raw: String): String? {
         if (raw.isBlank()) return null
         val trimmed = raw.trim()
-        if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) return null
+        if (!trimmed.startsWith("http://", ignoreCase = true) &&
+            !trimmed.startsWith("https://", ignoreCase = true)
+        ) return null
         return normaliseInstagramRanges(trimmed)
     }
 


### PR DESCRIPTION
## Summary
- restore the original trimming-based media filtering so non-Instagram sites surface their playable URLs again
- keep Instagram range-parameter normalization while allowing case-insensitive http/https detection

## Testing
- `./gradlew test` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cc86f020832ab0bf9e6898e2bbf5