### PR TITLE
Improve HLS detection and thumbnails

### DIFF
--- a/app/src/main/java/com/example/maxscraper/HlsThumbs.kt
+++ b/app/src/main/java/com/example/maxscraper/HlsThumbs.kt
@@ -16,14 +16,14 @@ import java.net.URL
 object HlsThumbs {
     fun loadInto(view: ImageView, m3u8Url: String) {
         Thread {
-            val bmp = tryMakeThumb(view, m3u8Url)
+            val bmp = fetchBitmap(m3u8Url)
             (view.context as? android.app.Activity)?.runOnUiThread {
                 if (bmp != null) view.setImageBitmap(bmp)
             }
         }.start()
     }
 
-    private fun tryMakeThumb(view: ImageView, m3u8Url: String): Bitmap? {
+    fun fetchBitmap(m3u8Url: String): Bitmap? {
         if (m3u8Url.endsWith(".mp4", true)) return frameFromUrl(m3u8Url)
         val playlist = fetchText(m3u8Url) ?: return null
 


### PR DESCRIPTION
## Summary
- launch the HLS quality picker when a detected media option is an m3u8 stream
- generate per-item thumbnails by probing the media stream instead of reusing the OG image
- expose a reusable bitmap fetcher in HlsThumbs so both the picker and HLS UI can share preview logic

## Testing
- ./gradlew lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cfcf5e74832a8896485f45d64827