### PR TITLE
Show all detected media when playback is active

### DIFF
--- a/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
+++ b/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
@@ -477,7 +477,6 @@ class BrowserActivity : AppCompatActivity() {
         val playing = MediaDetector.getPlayingUrls()
         if (playing.isNotEmpty()) {
             playing.forEach { addIfValid(it, ordered) }
-            return ordered.toList()
         }
         MediaDetector.getCandidates().forEach { addIfValid(it, ordered) }
         domUrls.forEach { addIfValid(it, ordered) }


### PR DESCRIPTION
## Summary
- keep previously detected media in the picker even when a playing URL is present

## Testing
- ⚠️ `./gradlew test` *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0dcb88c18832aa22179e5e277af59