### PR TITLE
Improve MP4 detection and ignore unwanted hosts

### DIFF
--- a/app/src/main/java/com/example/maxscraper/MediaFilter.kt
+++ b/app/src/main/java/com/example/maxscraper/MediaFilter.kt
@@ -24,9 +24,12 @@ object MediaFilter {
         val ext = fileExt(low)
         if (ext in BIN_EXTS) return false
         if (ext == "mp4") return true
+        if (MP4_SUFFIX_REGEX.containsMatchIn(low)) return true
         if (MP4_HINTS.any { low.contains(it) }) return true
         return false
     }
+
+    private val MP4_SUFFIX_REGEX = Regex("\\.mp4(?=($|[?#]))")
 
     private fun fileExt(u: String): String {
         return try {


### PR DESCRIPTION
## Summary
- expand MP4 detection so URLs with .mp4 query strings are treated as playable media
- extend ignored host handling to cover the additional ad and NSFW domains from the provided list

## Testing
- ./gradlew test *(fails: Android SDK is not configured in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e3bd3a08832a99045d45c60f3b90