### PR TITLE
Guard media picker dialog against inactive activity

### DIFF
--- a/app/src/main/java/com/example/maxscraper/MediaPicker.kt
+++ b/app/src/main/java/com/example/maxscraper/MediaPicker.kt
@@ -2,6 +2,8 @@ package com.example.maxscraper.ui
 
 import android.content.Context
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
 import com.example.maxscraper.R
 
 /**
@@ -30,8 +32,27 @@ object MediaPicker {
             metaId = metaId
         )
 
-        val dlg = adapter.asDialog(AlertDialog.Builder(ctx).setTitle(title))
-        dlg.setOnDismissListener { adapter.cleanup() }
-        dlg.show()
+        val dialog = adapter.asDialog(AlertDialog.Builder(ctx).setTitle(title))
+        dialog.setOnDismissListener { adapter.cleanup() }
+
+        val activity = ctx as? AppCompatActivity
+        if (activity != null) {
+            if (activity.isFinishing || activity.isDestroyed ||
+                !activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+            ) {
+                adapter.cleanup()
+                return
+            }
+
+            dialog.setOnShowListener {
+                if (activity.isFinishing || activity.isDestroyed ||
+                    !activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+                ) {
+                    dialog.dismiss()
+                }
+            }
+        }
+
+        dialog.show()
     }
 }


### PR DESCRIPTION
## Summary
- prevent the media picker dialog from showing when the hosting activity is finishing or not resumed
- dismiss the dialog automatically if the activity becomes inactive while it is showing to avoid crashes

## Testing
- `./gradlew lint` *(fails: SDK location not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e621a574832a842ab14fc2f3e761