### PR TITLE
Prioritize m3u8 streams in media picker

### DIFF
--- a/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
+++ b/app/src/main/java/com/example/maxscraper/BrowserActivity.kt
@@ -389,7 +389,10 @@ class BrowserActivity : AppCompatActivity() {
 
         return built
             .distinctBy { it.first.url }
-            .sortedByDescending { it.second }
+            .sortedWith(
+                compareByDescending<Pair<MediaOption, Long>> { it.first.isHls }
+                    .thenByDescending { it.second }
+            )
             .map { it.first }
     }
 


### PR DESCRIPTION
## Summary
- ensure HLS playlist entries appear at the top of the media picker
- keep remaining media options ordered by descending size hints for easier selection

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f3ae7154832abe05d59c9c37ef5b