### PR TITLE
Fix RecyclerView toggle using adapterPosition for compatibility

### DIFF
--- a/app/src/main/java/com/example/maxscraper/M3u8Activity.kt
+++ b/app/src/main/java/com/example/maxscraper/M3u8Activity.kt
@@ -117,7 +117,7 @@ class M3u8Activity : AppCompatActivity() {
         }
         override fun onBindViewHolder(holder: VH, position: Int) {
             holder.bind(data[position]) {
-                val pos = holder.bindingAdapterPosition
+                val pos = holder.adapterPosition
                 if (pos == RecyclerView.NO_POSITION) return@bind
                 val row = data[pos]
                 row.checked = !row.checked


### PR DESCRIPTION
## Summary
- use adapterPosition when toggling selection so the project builds against RecyclerView versions without the bindingAdapterPosition property

## Testing
- ./gradlew lint *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f7f19e88832aabdc858ffcc9ceb7